### PR TITLE
feat: read `NPM_VERSION` from `package.json`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict = true

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,11 +1,16 @@
 const core = require("@actions/core");
 const { exec } = require("@actions/exec");
+const pkg = require("../package.json");
 const audit = require("./audit");
 const auditFix = require("./auditFix");
 const report = require("./report");
 const createPullRequest = require("./createPullRequest");
 
-const NPM_VERSION = "6.13.7";
+const NPM_VERSION = pkg.engines.npm;
+
+if (!NPM_VERSION) {
+  throw new Error(`No NPM_VERSION!`);
+}
 
 async function run() {
   try {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     "JavaScript"
   ],
   "repository": "ybiquitous/npm-audit-fix-action",
+  "engines": {
+    "node": ">=12.13.0",
+    "npm": "6.13.7"
+  },
   "main": "lib/index.js",
   "scripts": {
     "package": "ncc build lib/index.js -o dist",


### PR DESCRIPTION
This uses the [`engines`](https://docs.npmjs.com/files/package.json#engines) field in `package.json`.
Also, this sets the [`engine-strict`](https://docs.npmjs.com/misc/config#engine-strict) configuration.