### PR TITLE
test: remove unneeded `updateNpm.test.js`

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2444,15 +2444,11 @@ function authenticationPlugin(octokit, options) {
 const { exec } = __webpack_require__(986);
 const npmArgs = __webpack_require__(510);
 
-function npmVersion() {
-  return "6.14.1";
-}
+const NPM_VERSION = "6.14.1";
 
 module.exports = function updateNpm() {
-  return exec("sudo", ["npm", ...npmArgs("install", "--global", `npm@${npmVersion()}`)]);
+  return exec("sudo", ["npm", ...npmArgs("install", "--global", `npm@${NPM_VERSION}`)]);
 };
-
-module.exports.npmVersion = npmVersion; // Export for test
 
 
 /***/ }),

--- a/lib/__tests__/updateNpm.test.js
+++ b/lib/__tests__/updateNpm.test.js
@@ -1,6 +1,0 @@
-const pkg = require("../../package.json");
-const { npmVersion } = require("../updateNpm");
-
-test("npmVersion()", () => {
-  expect(npmVersion()).toBe(pkg.engines.npm);
-});

--- a/lib/updateNpm.js
+++ b/lib/updateNpm.js
@@ -1,12 +1,8 @@
 const { exec } = require("@actions/exec");
 const npmArgs = require("./npmArgs");
 
-function npmVersion() {
-  return "6.14.1";
-}
+const NPM_VERSION = "6.14.1";
 
 module.exports = function updateNpm() {
-  return exec("sudo", ["npm", ...npmArgs("install", "--global", `npm@${npmVersion()}`)]);
+  return exec("sudo", ["npm", ...npmArgs("install", "--global", `npm@${NPM_VERSION}`)]);
 };
-
-module.exports.npmVersion = npmVersion; // Export for test


### PR DESCRIPTION
If `engines.npm` in `package.json` differs from the `NPM_VERSION` constant, the smoke test should fail.