### PR TITLE
feat: change default `commit_title`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # branch: "npm-audit-fix"
           # default_branch: "master"
-          # commit_title: "chore(deps): npm audit fix"
+          # commit_title: "build(deps): npm audit fix"
 ```
 
 ## Screenshot

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
   commit_title:
     description: "Commit title"
     required: false
-    default: "chore(deps): npm audit fix"
+    default: "build(deps): npm audit fix"
 runs:
   using: "node12"
   main: "dist/index.js"


### PR DESCRIPTION
This changes `chore` to `build`. This convention is according to the following:

- [Conventional Commits](https://www.conventionalcommits.org)
- [Angular](https://github.com/angular/angular/blob/ed1b4a8/CONTRIBUTING.md#type).

> build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)