### PR TITLE
fix: make file and git dependencies work

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -55,8 +55,9 @@ async function run() {
       return res;
     });
 
-    const report = await core.group("Aggregate report", () => {
-      return aggregateReport(auditReport, fixReport);
+    const report = await core.group("Aggregate report", async () => {
+      const res = await aggregateReport(auditReport, fixReport);
+      return res;
     });
 
     if (report.packageCount === 0) {

--- a/lib/packageRepoUrls.js
+++ b/lib/packageRepoUrls.js
@@ -17,14 +17,27 @@ async function fetchUrl(packageName) {
   }
 
   let stdout = "";
-  await exec("npm", ["view", packageName, "repository.url"], {
-    listeners: {
-      stdout: (data) => {
-        stdout += data.toString();
+  let stderr = "";
+  try {
+    await exec("npm", ["view", packageName, "repository.url"], {
+      listeners: {
+        stdout: (data) => {
+          stdout += data.toString();
+        },
+        stderr: (data) => {
+          stderr += data.toString();
+        },
       },
-    },
-    silent: true,
-  });
+      silent: true,
+    });
+  } catch (err) {
+    // code E404 means the package does not exist on npm
+    // which means it is a file: or git: dependency
+    // We are fine with 404 errors, but not with any other errors
+    if (!stderr.includes("code E404")) {
+      throw new Error(stderr);
+    }
+  }
   stdout = stdout.trim();
 
   if (!stdout) {


### PR DESCRIPTION
Currently if a dependency using the `file:`, `git:`, or `github:` protocols then this action fails to work because `npm view` will return a 404 for the dependency.

This is a link to a project which uses the `github:` protocol and shows the action failing to run -- https://github.com/Financial-Times/origami-component-converter/runs/832695920?check_suite_focus=true

My patch makes the github action ignore 404 errors and to surface other errors with their corresponding error message instead of just the exit code.