### PR TITLE
ci(actions): use `$default-branch` macro

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -2,7 +2,7 @@ name: commitlint
 
 on:
   push:
-    branches: ["master"]
+    branches: [$default-branch]
   pull_request:
     branches: ["**"]
 

--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: 0 0 * * *
   workflow_dispatch:
-    branches: ["master"]
+    branches: [$default-branch]
 
 jobs:
   npm-audit-fix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   workflow_dispatch:
-    branches: ["master"]
+    branches: [$default-branch]
     inputs:
       dry-run:
         description: Set `true` if you want to dry-run

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   push:
-    branches: ["master"]
+    branches: [$default-branch]
   pull_request:
     branches: ["**"]
     tags: ["**"]

--- a/goodcheck.yml
+++ b/goodcheck.yml
@@ -1,0 +1,10 @@
+import:
+  - https://raw.githubusercontent.com/sider/goodcheck-rules/master/rules/github.yml
+  - https://raw.githubusercontent.com/sider/goodcheck-rules/master/rules/typo.yml
+
+exclude:
+  - dist
+  - node_modules
+  - package-lock.json
+  - "**/*.png"
+  - "**/*.log"


### PR DESCRIPTION
See https://github.blog/changelog/2020-07-22-github-actions-better-support-for-alternative-default-branch-names/

Also, this change introduces Goodcheck to use the following rule:
https://github.com/sider/goodcheck-rules/blob/cf63d780b5a8c21ec908a0c871c99a4a10a18747/rules/github.yml#L1