### PR TITLE
feat: add `github_token` default and remove `env.GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,5 +37,3 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This action runs [`npm audit fix`](https://docs.npmjs.com/cli/audit) and creates
 
 ## Usage
 
-For example, you can add this action by creating `.github/workflows/npm-audit-fix.yml` as follows:
+For example, you can add this action by creating [`.github/workflows/npm-audit-fix.yml`](.github/workflows/npm-audit-fix.yml):
 
 ```yaml
 name: npm audit fix
@@ -23,22 +23,19 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: ybiquitous/npm-audit-fix-action@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          # branch: "npm-audit-fix-action/fix"
-          # default_branch: "master"
-          # commit_title: "build(deps): npm audit fix"
-          # labels: "dependencies, security"
-        # or
-        # env:
-        #   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # with:
+        #   github_token: ${{ github.token }}
+        #   branch: "npm-audit-fix-action/fix"
+        #   default_branch: "master"
+        #   commit_title: "build(deps): npm audit fix"
+        #   labels: "dependencies, security"
 ```
 
-Here is a [sample](.github/workflows/npm-audit-fix.yml).
+See also [`action.yml`](action.yml) about the available options.
 
 ### Using a personal access token
 
-If you want to run your CI with pull requests created by this action, you may need to set your [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) instead of `secrets.GITHUB_TOKEN`:
+If you want to run your CI with pull requests created by this action, you may need to set your [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) instead of the GitHub's default token:
 
 For example:
 
@@ -47,8 +44,8 @@ with:
   github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 ```
 
-The reason is that `GITHUB_TOKEN` does not have enough permissions to trigger CI.
-See also the [GitHub document](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token) about the `GITHUB_TOKEN` permissions.
+The reason is that the default token does not have enough permissions to trigger CI.
+See also the [GitHub document](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token) about the token permissions.
 
 ## Screenshot
 

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,7 @@ inputs:
   github_token:
     description: "GitHub token"
     required: false
+    default: ${{ github.token }}
   branch:
     description: "Created branch"
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -7194,7 +7194,7 @@ async function run() {
     await core.group("Create or update a pull request", () => {
       return createOrUpdatePullRequest({
         branch: core.getInput("branch"),
-        token: core.getInput("github_token") || getFromEnv("GITHUB_TOKEN"),
+        token: core.getInput("github_token"),
         defaultBranch: core.getInput("default_branch"),
         title: core.getInput("commit_title"),
         body: buildPullRequestBody(report),

--- a/lib/index.js
+++ b/lib/index.js
@@ -75,7 +75,7 @@ async function run() {
     await core.group("Create or update a pull request", () => {
       return createOrUpdatePullRequest({
         branch: core.getInput("branch"),
-        token: core.getInput("github_token") || getFromEnv("GITHUB_TOKEN"),
+        token: core.getInput("github_token"),
         defaultBranch: core.getInput("default_branch"),
         title: core.getInput("commit_title"),
         body: buildPullRequestBody(report),


### PR DESCRIPTION
BREAKING CHANGE: `with.github_token` is no longer required and `env.GITHUB_TOKEN` is ignored.