### PR TITLE
feat(deps): bump npm from 6.14.11 to 7.4.3

### DIFF
--- a/lib/__tests__/buildPullRequestBody.test.js
+++ b/lib/__tests__/buildPullRequestBody.test.js
@@ -25,7 +25,7 @@ test("buildPullRequestBody()", () => {
 
 ***
 
-This pull request is created by [npm-audit-fix-action](https://github.com/ybiquitous/npm-audit-fix-action). The used npm version is **6.14.11**.
+This pull request is created by [npm-audit-fix-action](https://github.com/ybiquitous/npm-audit-fix-action). The used npm version is **7.4.3**.
 `.trim()
   );
 });

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,3 +1,3 @@
 module.exports.PACKAGE_NAME = "npm-audit-fix-action";
 module.exports.PACKAGE_URL = "https://github.com/ybiquitous/npm-audit-fix-action";
-module.exports.NPM_VERSION = "6.14.11";
+module.exports.NPM_VERSION = "7.4.3";

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "repository": "ybiquitous/npm-audit-fix-action",
   "engines": {
     "node": ">=12.13.0",
-    "npm": "6.14.11"
+    "npm": "7.4.3"
   },
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
See <https://github.blog/2020-10-13-presenting-v7-0-0-of-the-npm-cli/>

Note: Dependabot does not support npm 7 yet. So `package-lock.json` is still v1.