### PR TITLE
fix: re-run `npm ci` for more accurate diff list

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7402,6 +7402,7 @@ module.exports.Collection = Hook.Collection
 
 const core = __webpack_require__(470);
 const { exec } = __webpack_require__(986);
+
 const { NPM_VERSION } = __webpack_require__(32);
 const audit = __webpack_require__(50);
 const auditFix = __webpack_require__(905);
@@ -7455,6 +7456,10 @@ async function run() {
   const beforePackages = await core.group("List packages before", () => listPackages());
 
   await core.group("Fix vulnerabilities", () => auditFix());
+
+  await core.group("Re-install user packages", async () => {
+    await exec("npm", npmArgs("ci"));
+  });
 
   const afterPackages = await core.group("List packages after", () => listPackages());
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 const core = require("@actions/core");
 const { exec } = require("@actions/exec");
+
 const { NPM_VERSION } = require("./constants");
 const audit = require("./audit");
 const auditFix = require("./auditFix");
@@ -53,6 +54,10 @@ async function run() {
   const beforePackages = await core.group("List packages before", () => listPackages());
 
   await core.group("Fix vulnerabilities", () => auditFix());
+
+  await core.group("Re-install user packages", async () => {
+    await exec("npm", npmArgs("ci"));
+  });
 
   const afterPackages = await core.group("List packages after", () => listPackages());
 


### PR DESCRIPTION
For some reason, it is necessary to re-run `npm ci` after `npm audit fix`.