### PR TITLE
fix: ignore return code of `npm audit fix`

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -9100,8 +9100,20 @@ exports.withCustomRequest = withCustomRequest;
 const { exec } = __webpack_require__(986);
 const npmArgs = __webpack_require__(510);
 
-module.exports = function auditFix() {
-  return exec("npm", npmArgs("audit", "fix"));
+module.exports = async function auditFix() {
+  let error = "";
+  await exec("npm", npmArgs("audit", "fix"), {
+    listeners: {
+      stderr: (data) => {
+        error += data.toString();
+      },
+    },
+    ignoreReturnCode: true,
+  });
+
+  if (error.includes("npm ERR!")) {
+    throw new Error("Unexpected error occured");
+  }
 };
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -9112,7 +9112,7 @@ module.exports = async function auditFix() {
   });
 
   if (error.includes("npm ERR!")) {
-    throw new Error("Unexpected error occured");
+    throw new Error("Unexpected error occurred");
   }
 };
 

--- a/lib/auditFix.js
+++ b/lib/auditFix.js
@@ -13,6 +13,6 @@ module.exports = async function auditFix() {
   });
 
   if (error.includes("npm ERR!")) {
-    throw new Error("Unexpected error occured");
+    throw new Error("Unexpected error occurred");
   }
 };

--- a/lib/auditFix.js
+++ b/lib/auditFix.js
@@ -1,6 +1,18 @@
 const { exec } = require("@actions/exec");
 const npmArgs = require("./npmArgs");
 
-module.exports = function auditFix() {
-  return exec("npm", npmArgs("audit", "fix"));
+module.exports = async function auditFix() {
+  let error = "";
+  await exec("npm", npmArgs("audit", "fix"), {
+    listeners: {
+      stderr: (data) => {
+        error += data.toString();
+      },
+    },
+    ignoreReturnCode: true,
+  });
+
+  if (error.includes("npm ERR!")) {
+    throw new Error("Unexpected error occured");
+  }
 };


### PR DESCRIPTION
`npm audit fix` can return code `1` when no fix available.