### PR TITLE
fix: output warning when `npm audit fix` returns non-zero

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -9097,12 +9097,14 @@ exports.withCustomRequest = withCustomRequest;
 /***/ 905:
 /***/ (function(module, __unusedexports, __webpack_require__) {
 
+const { warning } = __webpack_require__(470);
 const { exec } = __webpack_require__(986);
 const npmArgs = __webpack_require__(510);
 
 module.exports = async function auditFix() {
   let error = "";
-  await exec("npm", npmArgs("audit", "fix"), {
+
+  const returnCode = await exec("npm", npmArgs("audit", "fix"), {
     listeners: {
       stderr: (data) => {
         error += data.toString();
@@ -9113,6 +9115,10 @@ module.exports = async function auditFix() {
 
   if (error.includes("npm ERR!")) {
     throw new Error("Unexpected error occurred");
+  }
+
+  if (returnCode !== 0) {
+    warning(error);
   }
 };
 

--- a/lib/auditFix.js
+++ b/lib/auditFix.js
@@ -1,9 +1,11 @@
+const { warning } = require("@actions/core");
 const { exec } = require("@actions/exec");
 const npmArgs = require("./npmArgs");
 
 module.exports = async function auditFix() {
   let error = "";
-  await exec("npm", npmArgs("audit", "fix"), {
+
+  const returnCode = await exec("npm", npmArgs("audit", "fix"), {
     listeners: {
       stderr: (data) => {
         error += data.toString();
@@ -14,5 +16,9 @@ module.exports = async function auditFix() {
 
   if (error.includes("npm ERR!")) {
     throw new Error("Unexpected error occurred");
+  }
+
+  if (returnCode !== 0) {
+    warning(error);
   }
 };


### PR DESCRIPTION
Follow-up of #410