### PR TITLE
fix: allow npm@8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       },
       "engines": {
         "node": ">=12.20.0",
-        "npm": ">=7 <8"
+        "npm": ">=7 <9"
       }
     },
     "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "repository": "ybiquitous/npm-audit-fix-action",
   "engines": {
     "node": ">=12.20.0",
-    "npm": ">=7 <8"
+    "npm": ">=7 <9"
   },
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
npm@8 has been released! It seems the breaking changes do not have any problems.
See <https://github.com/npm/cli/releases/tag/v8.0.0>