### PR TITLE
ci: fix actionlint issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - run: git config --local user.name '${{ github.actor }}'
       - run: git config --local user.email '${{ github.actor }}@users.noreply.github.com'
       - run: npm run release
-      - run: echo ::set-output name=tag::$(git describe --abbrev=0)
+      - run: echo "::set-output name=tag::$(git describe --abbrev=0)"
         id: get_tag
       - run: git push --follow-tags
       - run: git tag --force --annotate --message 'Release v3' v3


### PR DESCRIPTION
```console
$ actionlint
.github/workflows/release.yml:18:9: shellcheck reported issue in this script: SC2046:warning:1:29: Quote this to prevent word splitting [shellcheck]
   |
18 |       - run: echo ::set-output name=tag::$(git describe --abbrev=0)
   |         ^~~~
```