### PR TITLE
feat(deps): bump npm from 7 to 8

### DIFF
--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -9283,7 +9283,7 @@ function buildCommitBody(report) {
 ;// CONCATENATED MODULE: ./lib/constants.js
 const PACKAGE_NAME = "ybiquitous/npm-audit-fix-action";
 const PACKAGE_URL = "https://github.com/ybiquitous/npm-audit-fix-action";
-const NPM_VERSION = "7";
+const NPM_VERSION = "8";
 
 ;// CONCATENATED MODULE: ./lib/buildPullRequestBody.js
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,3 +1,3 @@
 export const PACKAGE_NAME = "ybiquitous/npm-audit-fix-action";
 export const PACKAGE_URL = "https://github.com/ybiquitous/npm-audit-fix-action";
-export const NPM_VERSION = "7";
+export const NPM_VERSION = "8";

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "repository": "ybiquitous/npm-audit-fix-action",
   "engines": {
     "node": ">=12.20.0",
-    "npm": ">=7 <9"
+    "npm": ">=8"
   },
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
npm@8 has some breaking changes, but they do not affect this action.

https://github.com/npm/cli/releases/tag/v8.0.0