### PR TITLE
fix: `permissions.contents` from `read` to `write`

### DIFF
--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -9,7 +9,7 @@ jobs:
   npm-audit-fix:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
   smoke:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ jobs:
   npm-audit-fix:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This PR fixes the following error:

```
...
  /usr/bin/git push ***github.com/ybiquitous/npm-audit-fix-action.git HEAD:npm-audit-fix-action/fix --force
  remote: Permission to ybiquitous/npm-audit-fix-action.git denied to github-actions[bot].
  fatal: unable to access 'https://github.com/ybiquitous/npm-audit-fix-action.git/': The requested URL returned error: 403
Error: The process '/usr/bin/git' failed with exit code 128
```

https://github.com/ybiquitous/npm-audit-fix-action/actions/runs/3825821567/jobs/6509083089#step:3:2931