### PR TITLE
chore: enable `engine-strict` only on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: ["**"]
 
+env:
+  # HACK: Dependabot uses Node.js 16.20.1 and npm 8.19.4, so `engine-strict=true` in `.npmrc` fails Dependabot.
+  # See https://github.com/ybiquitous/npm-audit-fix-action/network/updates/689567062
+  npm_config_engine_strict: true
+
 jobs:
   unit:
     runs-on: ubuntu-latest

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-engine-strict = true


### PR DESCRIPTION
Dependabot uses Node.js 16.20.1 and npm 8.19.4, so `engine-strict=true` in `.npmrc` fails Dependabot.
See https://github.com/ybiquitous/npm-audit-fix-action/network/updates/689567062
