### PR TITLE
fix: running Node.js version when using `exec()`

### DIFF
--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -10964,6 +10964,9 @@ async function run() {
   core2.info(`Running on Node.js ${import_node_process3.default.version}`);
   core2.addPath(import_node_process3.default.execPath.replace(/\/node$/u, ""));
   const npmVersion = await core2.group(`Update npm to ${NPM_VERSION}`, () => updateNpm(NPM_VERSION));
+  await core2.group("Show runtime info", async () => {
+    await (0, import_exec7.exec)("npm", ["version"]);
+  });
   await core2.group("Install user packages", async () => {
     await (0, import_exec7.exec)("npm", npmArgs("ci"));
   });

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -2064,7 +2064,7 @@ var require_core = __commonJS({
       command_1.issueCommand("add-mask", {}, secret);
     }
     exports.setSecret = setSecret;
-    function addPath(inputPath) {
+    function addPath2(inputPath) {
       const filePath = process.env["GITHUB_PATH"] || "";
       if (filePath) {
         file_command_1.issueFileCommand("PATH", inputPath);
@@ -2073,7 +2073,7 @@ var require_core = __commonJS({
       }
       process.env["PATH"] = `${inputPath}${path.delimiter}${process.env["PATH"]}`;
     }
-    exports.addPath = addPath;
+    exports.addPath = addPath2;
     function getInput2(name, options) {
       const val = process.env[`INPUT_${name.replace(/ /g, "_").toUpperCase()}`] || "";
       if (options && options.required && !val) {
@@ -10961,6 +10961,8 @@ function getFromEnv(name) {
   throw new Error(`Not found '${name}' in the environment variables`);
 }
 async function run() {
+  core2.info(`Running on Node.js ${import_node_process3.default.version}`);
+  core2.addPath(import_node_process3.default.execPath.replace(/\/node$/u, ""));
   const npmVersion = await core2.group(`Update npm to ${NPM_VERSION}`, () => updateNpm(NPM_VERSION));
   await core2.group("Install user packages", async () => {
     await (0, import_exec7.exec)("npm", npmArgs("ci"));

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,6 +39,9 @@ function getFromEnv(name) {
 }
 
 async function run() {
+  core.info(`Running on Node.js ${process.version}`);
+  core.addPath(process.execPath.replace(/\/node$/u, ""));
+
   const npmVersion = await core.group(`Update npm to ${NPM_VERSION}`, () => updateNpm(NPM_VERSION));
 
   await core.group("Install user packages", async () => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,6 +44,10 @@ async function run() {
 
   const npmVersion = await core.group(`Update npm to ${NPM_VERSION}`, () => updateNpm(NPM_VERSION));
 
+  await core.group("Show runtime info", async () => {
+    await exec("npm", ["version"]);
+  });
+
   await core.group("Install user packages", async () => {
     await exec("npm", npmArgs("ci"));
   });


### PR DESCRIPTION
By default, `exec()` tries using the pre-installed Node.js instead of `runs` in `action.yml`.
This change fixes the bug by adding `runs` Node.js path to the `PATH` environment variable.
