### PR TITLE
chore: simplify `tsconfig.json` thanks to `@tsconfig/strictest`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@jest/globals": "^29.6.4",
+        "@tsconfig/strictest": "^2.0.2",
         "@types/hosted-git-info": "^3.0.2",
         "@typescript-eslint/eslint-plugin": "^6.5.0",
         "esbuild": "^0.19.2",
@@ -2433,6 +2434,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/strictest": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/strictest/-/strictest-2.0.2.tgz",
+      "integrity": "sha512-jt4jIsWKvUvuY6adJnQJlb/UR7DdjC8CjHI/OaSQruj2yX9/K6+KOvDt/vD6udqos/FUk5Op66CvYT7TBLYO5Q==",
       "dev": true
     },
     "node_modules/@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.6.4",
+    "@tsconfig/strictest": "^2.0.2",
     "@types/hosted-git-info": "^3.0.2",
     "@typescript-eslint/eslint-plugin": "^6.5.0",
     "esbuild": "^0.19.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,10 @@
 {
+  "extends": "@tsconfig/strictest",
   "compilerOptions": {
-    "checkJs": true,
-    "strict": true,
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitReturns": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noUncheckedIndexedAccess": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true,
-    "module": "ES2020",
-    "moduleResolution": "node",
-    "lib": ["ES2020"]
+    "lib": ["es2023"],
+    "target": "es2022",
+    "module": "node16",
+    "moduleResolution": "node16"
   },
   "exclude": ["dist/**", "coverage/**"]
 }


### PR DESCRIPTION
In addition, it partially refers to https://github.com/tsconfig/bases/blob/031273b815ff7f672c7c9057fb7d19ef363054b1/bases/node20.json