### PR TITLE
fix: always overwrite branch even if PR were already closed

### DIFF
--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -25390,7 +25390,7 @@ async function createOrUpdatePullRequest({
 
 ${commitBody}`]);
   await (0, import_exec4.exec)("git", ["checkout", "-B", branch]);
-  await (0, import_exec4.exec)("git", ["push", remote, `HEAD:${branch}`, ...pull ? ["--force"] : []]);
+  await (0, import_exec4.exec)("git", ["push", "--force", remote, `HEAD:${branch}`]);
   if (pull) {
     await octokit.rest.pulls.update({
       owner,

--- a/lib/createOrUpdatePullRequest.js
+++ b/lib/createOrUpdatePullRequest.js
@@ -50,7 +50,7 @@ export default async function createOrUpdatePullRequest({
   await exec("git", ["add", "package-lock.json"]);
   await exec("git", ["commit", "--message", `${title}\n\n${commitBody}`]);
   await exec("git", ["checkout", "-B", branch]);
-  await exec("git", ["push", remote, `HEAD:${branch}`, ...(pull ? ["--force"] : [])]);
+  await exec("git", ["push", "--force", remote, `HEAD:${branch}`]);
 
   if (pull) {
     await octokit.rest.pulls.update({


### PR DESCRIPTION
Fixes #884

Before:
When a PR was closed but the PR's branch (e.g. `npm-audit-fix-action/fix`) was not deleted,
pushing a new branch (but the same name) fails.

After:
Even if a PR was closed, this change always tries overwriting the PR's branch.
If a branch is not created yet, creating a branch passes as before.
