### PR TITLE
chore(deps): temporarily disable ESLint major updates for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,8 @@ updates:
     versioning-strategy: increase
     groups:
       eslint:
-        patterns: ["eslint", "eslint-*", "@typescript-eslint/*"]
+        # TODO: Include "eslint" when all plugins support ESLint v9.
+        patterns: ["eslint-*", "@typescript-eslint/*"]
       jest:
         patterns: ["jest", "@jest/*"]
       typescript:


### PR DESCRIPTION
Closes #900

To prevent CI errors like <https://github.com/ybiquitous/npm-audit-fix-action/actions/runs/9947237051/job/27479486904?pr=900#step:5:5>.