### PR TITLE
feat!: bump npm from 10 to 11

### DIFF
--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -25199,7 +25199,7 @@ function buildCommitBody({ updated, added, removed }) {
 // lib/constants.js
 var PACKAGE_NAME = "ybiquitous/npm-audit-fix-action";
 var PACKAGE_URL = "https://github.com/ybiquitous/npm-audit-fix-action";
-var NPM_VERSION = "10";
+var NPM_VERSION = "11";
 
 // lib/buildPullRequestBody.js
 var EMPTY = "-";

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,3 +1,3 @@
 export const PACKAGE_NAME = "ybiquitous/npm-audit-fix-action";
 export const PACKAGE_URL = "https://github.com/ybiquitous/npm-audit-fix-action";
-export const NPM_VERSION = "10";
+export const NPM_VERSION = "11";

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
       },
       "engines": {
         "node": "20",
-        "npm": "10"
+        "npm": "11"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "repository": "ybiquitous/npm-audit-fix-action",
   "engines": {
     "node": "20",
-    "npm": "10"
+    "npm": "11"
   },
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
npm v11.0.0 was released on 2024-12-16.
Ref https://github.com/npm/cli/releases/tag/v11.0.0

The previous update:
- #834