### PR TITLE
ci: prepare for v7 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       major_version_tag:
         description: "Major version tag"
         required: true
-        default: "v6"
+        default: "v7"
         type: string
 
 jobs:


### PR DESCRIPTION
PR #981 will be released as v7 (the next major version).
