### PR TITLE
feat: add action run link to generated pull request body

### DIFF
--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -25222,7 +25222,7 @@ var detail = ({ severity, title, url }) => {
   }
   return EMPTY;
 };
-function buildPullRequestBody(report, npmVersion) {
+function buildPullRequestBody({ report, npmVersion, github: github2 }) {
   const header = [];
   header.push("| Package | Version | Source | Detail |");
   header.push("|:--------|:-------:|:------:|:-------|");
@@ -25290,7 +25290,9 @@ function buildPullRequestBody(report, npmVersion) {
   lines.push("");
   lines.push("***");
   lines.push("");
-  lines.push(`Created by [${PACKAGE_NAME}](${PACKAGE_URL})`);
+  lines.push(
+    `Created by [${PACKAGE_NAME}](${PACKAGE_URL}) in the [action run](${github2.serverUrl}/${github2.repository}/actions/runs/${github2.runId})`
+  );
   return lines.join("\n").trim();
 }
 
@@ -25506,12 +25508,18 @@ async function run() {
     const author = core2.getInput("github_user");
     const email = core2.getInput("github_email");
     const assignees = commaSeparatedList(core2.getInput("assignees"));
+    const serverUrl = getFromEnv("GITHUB_SERVER_URL");
+    const runId = getFromEnv("GITHUB_RUN_ID");
     return createOrUpdatePullRequest({
       branch: core2.getInput("branch"),
       token,
       baseBranch,
       title: core2.getInput("commit_title"),
-      pullBody: buildPullRequestBody(report, npmVersion),
+      pullBody: buildPullRequestBody({
+        report,
+        npmVersion,
+        github: { serverUrl, repository, runId }
+      }),
       commitBody: buildCommitBody(report),
       repository,
       author,

--- a/lib/__tests__/buildPullRequestBody.test.js
+++ b/lib/__tests__/buildPullRequestBody.test.js
@@ -6,9 +6,15 @@ import buildPullRequestBody from "../buildPullRequestBody.js";
 
 const report = JSON.parse(readFileSync(new URL("./fixtures/report.json", import.meta.url), "utf8"));
 
+const github = {
+  serverUrl: "https://github.com",
+  repository: "octocat/Hello-World",
+  runId: "1658821493",
+};
+
 test("buildPullRequestBody()", () => {
   assert.equal(
-    buildPullRequestBody(report, "7.7.0"),
+    buildPullRequestBody({ report, npmVersion: "7.7.0", github }),
     `
 This pull request fixes the vulnerable packages via npm [7.7.0](https://github.com/npm/cli/releases/tag/v7.7.0).
 
@@ -42,7 +48,7 @@ This pull request fixes the vulnerable packages via npm [7.7.0](https://github.c
 
 ***
 
-Created by [ybiquitous/npm-audit-fix-action](https://github.com/ybiquitous/npm-audit-fix-action)
+Created by [ybiquitous/npm-audit-fix-action](https://github.com/ybiquitous/npm-audit-fix-action) in the [action run](https://github.com/octocat/Hello-World/actions/runs/1658821493)
 `.trim(),
   );
 });

--- a/lib/buildPullRequestBody.js
+++ b/lib/buildPullRequestBody.js
@@ -49,12 +49,13 @@ const detail = ({ severity, title, url }) => {
 };
 
 /**
- * @param {Report} report
- * @param {string} npmVersion
+ * @typedef {{ serverUrl: string, repository: string, runId: string }} GitHubInfo
+ *
+ * @param {{ report: Report, npmVersion: string, github: GitHubInfo }} args
  * @returns {string}
  */
 // eslint-disable-next-line max-lines-per-function, max-statements
-export default function buildPullRequestBody(report, npmVersion) {
+export default function buildPullRequestBody({ report, npmVersion, github }) {
   const header = [];
   header.push("| Package | Version | Source | Detail |");
   header.push("|:--------|:-------:|:------:|:-------|");
@@ -129,7 +130,9 @@ export default function buildPullRequestBody(report, npmVersion) {
   lines.push("");
   lines.push("***");
   lines.push("");
-  lines.push(`Created by [${PACKAGE_NAME}](${PACKAGE_URL})`);
+  lines.push(
+    `Created by [${PACKAGE_NAME}](${PACKAGE_URL}) in the [action run](${github.serverUrl}/${github.repository}/actions/runs/${github.runId})`,
+  );
 
   return lines.join("\n").trim();
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -102,12 +102,19 @@ async function run() {
     const email = core.getInput("github_email");
     const assignees = commaSeparatedList(core.getInput("assignees"));
 
+    const serverUrl = getFromEnv("GITHUB_SERVER_URL");
+    const runId = getFromEnv("GITHUB_RUN_ID");
+
     return createOrUpdatePullRequest({
       branch: core.getInput("branch"),
       token,
       baseBranch,
       title: core.getInput("commit_title"),
-      pullBody: buildPullRequestBody(report, npmVersion),
+      pullBody: buildPullRequestBody({
+        report,
+        npmVersion,
+        github: { serverUrl, repository, runId },
+      }),
       commitBody: buildCommitBody(report),
       repository,
       author,


### PR DESCRIPTION
Ref the default environment variables for GitHub Actions:
https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables

---

Test with the PR #989 body:

<img width="791" alt="image" src="https://github.com/user-attachments/assets/12a7185b-8bf7-4ba9-ab14-0343dee29c75" />

