### PR TITLE
feat: show notice message for generated pull requests

### DIFF
--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -19165,10 +19165,10 @@ Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
       (0, command_1.issueCommand)("warning", (0, utils_1.toCommandProperties)(properties), message instanceof Error ? message.toString() : message);
     }
     exports2.warning = warning2;
-    function notice(message, properties = {}) {
+    function notice2(message, properties = {}) {
       (0, command_1.issueCommand)("notice", (0, utils_1.toCommandProperties)(properties), message instanceof Error ? message.toString() : message);
     }
-    exports2.notice = notice;
+    exports2.notice = notice2;
     function info4(message) {
       process.stdout.write(message + os.EOL);
     }
@@ -25354,6 +25354,7 @@ ${commitBody}`]);
       body: pullBody
     });
     (0, import_core4.info)(`The pull request was updated successfully: ${pull.html_url}`);
+    (0, import_core4.notice)(`${PACKAGE_NAME} successfully updated PR #${pull.number}: ${pull.html_url}`);
   } else {
     const newPull = await octokit.rest.pulls.create({
       owner,
@@ -25364,6 +25365,9 @@ ${commitBody}`]);
       base: baseBranch
     });
     (0, import_core4.info)(`The pull request was created successfully: ${newPull.data.html_url}`);
+    (0, import_core4.notice)(
+      `${PACKAGE_NAME} successfully created PR #${newPull.data.number}: ${newPull.data.html_url}`
+    );
     const newLabels = await octokit.rest.issues.addLabels({
       owner,
       repo,

--- a/lib/createOrUpdatePullRequest.js
+++ b/lib/createOrUpdatePullRequest.js
@@ -1,6 +1,7 @@
-import { info } from "@actions/core";
+import { info, notice } from "@actions/core";
 import { exec } from "@actions/exec";
 import * as github from "@actions/github";
+import { PACKAGE_NAME } from "./constants.js";
 import splitRepo from "./utils/splitRepo.js";
 
 /**
@@ -64,6 +65,7 @@ export default async function createOrUpdatePullRequest({
       body: pullBody,
     });
     info(`The pull request was updated successfully: ${pull.html_url}`);
+    notice(`${PACKAGE_NAME} successfully updated PR #${pull.number}: ${pull.html_url}`);
   } else {
     const newPull = await octokit.rest.pulls.create({
       owner,
@@ -74,6 +76,9 @@ export default async function createOrUpdatePullRequest({
       base: baseBranch,
     });
     info(`The pull request was created successfully: ${newPull.data.html_url}`);
+    notice(
+      `${PACKAGE_NAME} successfully created PR #${newPull.data.number}: ${newPull.data.html_url}`,
+    );
 
     const newLabels = await octokit.rest.issues.addLabels({
       owner,


### PR DESCRIPTION
This enables people to move from an action run page to a pull request page more easily.

Ref https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-a-notice-message

---

Test:

<img width="945" alt="image" src="https://github.com/user-attachments/assets/018b27e4-9555-49ae-ac37-77e392c43152" />

https://github.com/ybiquitous/npm-audit-fix-action/actions/runs/13381286320?pr=990