### PR TITLE
fix: prevent linebreaks between versions in pull request body's table

### DIFF
--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -25240,7 +25240,7 @@ function buildPullRequestBody({ report, npmVersion, github: github2 }) {
       lines.push(
         buildTableRow(
           npmPackage(name, version, location),
-          `${versionLabel(previousVersion)} \u2192 ${versionLabel(version)}`,
+          `${versionLabel(previousVersion)}\u2192${versionLabel(version)}`,
           repoLink(report, name),
           detail({ severity, title, url })
         )

--- a/lib/__tests__/buildPullRequestBody.test.js
+++ b/lib/__tests__/buildPullRequestBody.test.js
@@ -23,8 +23,8 @@ This pull request fixes the vulnerable packages via npm [7.7.0](https://github.c
 
 | Package | Version | Source | Detail |
 |:--------|:-------:|:------:|:-------|
-| [minimist](https://www.npmjs.com/package/minimist/v/1.2.4) (\`foo/node_modules/minimist\`) | \`1.2.1\` → \`1.2.4\` | [github](https://github.com/substack/minimist) | - |
-| [mocha](https://www.npmjs.com/package/mocha/v/1.4.3) | \`1.3.0\` → \`1.4.3\` | [github](https://github.com/mochajs/mocha) | **[Low]** Prototype Pollution ([ref](https://npmjs.com/advisories/1179)) |
+| [minimist](https://www.npmjs.com/package/minimist/v/1.2.4) (\`foo/node_modules/minimist\`) | \`1.2.1\`→\`1.2.4\` | [github](https://github.com/substack/minimist) | - |
+| [mocha](https://www.npmjs.com/package/mocha/v/1.4.3) | \`1.3.0\`→\`1.4.3\` | [github](https://github.com/mochajs/mocha) | **[Low]** Prototype Pollution ([ref](https://npmjs.com/advisories/1179)) |
 
 </details>
 

--- a/lib/buildPullRequestBody.js
+++ b/lib/buildPullRequestBody.js
@@ -76,7 +76,7 @@ export default function buildPullRequestBody({ report, npmVersion, github }) {
       lines.push(
         buildTableRow(
           npmPackage(name, version, location),
-          `${versionLabel(previousVersion)} → ${versionLabel(version)}`,
+          `${versionLabel(previousVersion)}→${versionLabel(version)}`,
           repoLink(report, name),
           detail({ severity, title, url }),
         ),


### PR DESCRIPTION
Linebreaks make a table in a pull request body hard to view.



