### PR TITLE
fix: prevent too long column in pull request body's table

### DIFF
--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -25206,7 +25206,7 @@ var EMPTY = "-";
 var npmPackage = (name, version, location) => {
   let result = `[${name}](https://www.npmjs.com/package/${name}/v/${version})`;
   if (location != null) {
-    result += ` (\`${location}\`)`;
+    result += `<br>(\`${location}\`)`;
   }
   return result;
 };

--- a/lib/__tests__/buildPullRequestBody.test.js
+++ b/lib/__tests__/buildPullRequestBody.test.js
@@ -23,7 +23,7 @@ This pull request fixes the vulnerable packages via npm [7.7.0](https://github.c
 
 | Package | Version | Source | Detail |
 |:--------|:-------:|:------:|:-------|
-| [minimist](https://www.npmjs.com/package/minimist/v/1.2.4) (\`foo/node_modules/minimist\`) | \`1.2.1\`→\`1.2.4\` | [github](https://github.com/substack/minimist) | - |
+| [minimist](https://www.npmjs.com/package/minimist/v/1.2.4)<br>(\`foo/node_modules/minimist\`) | \`1.2.1\`→\`1.2.4\` | [github](https://github.com/substack/minimist) | - |
 | [mocha](https://www.npmjs.com/package/mocha/v/1.4.3) | \`1.3.0\`→\`1.4.3\` | [github](https://github.com/mochajs/mocha) | **[Low]** Prototype Pollution ([ref](https://npmjs.com/advisories/1179)) |
 
 </details>

--- a/lib/buildPullRequestBody.js
+++ b/lib/buildPullRequestBody.js
@@ -10,7 +10,7 @@ const EMPTY = "-";
 const npmPackage = (name, version, location) => {
   let result = `[${name}](https://www.npmjs.com/package/${name}/v/${version})`;
   if (location != null) {
-    result += ` (\`${location}\`)`;
+    result += `<br>(\`${location}\`)`;
   }
   return result;
 };


### PR DESCRIPTION
The following table could be hard to view (#989):
<img width="817" alt="image" src="https://github.com/user-attachments/assets/da6900a7-97d7-4706-8808-ce91551723ec" />
