### PR TITLE
chore: refine TypeScript configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lint:js:fix": "npm run lint:js -- --fix",
     "lint:md": "remark . --frail",
     "lint:md:fix": "remark . --output",
-    "lint:types": "tsc --noEmit",
+    "lint:types": "tsc",
     "lint:types:watch": "npm run lint:types -- --watch",
     "lint:commit": "commitlint --from HEAD~10",
     "lint:styles": "npm run prettier -- --check",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,9 @@
   "extends": "@tsconfig/strictest",
   "compilerOptions": {
     "lib": ["es2023"],
-    "target": "es2022",
-    "module": "node16",
-    "moduleResolution": "node16"
+    "target": "es2023",
+    "module": "nodenext",
+    "noEmit": true
   },
   "exclude": ["dist/**", "coverage/**"]
 }


### PR DESCRIPTION
Change summary:
- Move `--noEmit` to `tsconfig.json`.
- Update `target` and `module` in `tsconfig.json` to follow newer Node.js versions.
