### PR TITLE
fix: also commit `package.json`

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -34061,6 +34061,7 @@ async function createOrUpdatePullRequest({
 
   await (0,exec.exec)("git", ["config", "user.name", author]);
   await (0,exec.exec)("git", ["config", "user.email", email]);
+  await (0,exec.exec)("git", ["add", "package.json"]);
   await (0,exec.exec)("git", ["add", "package-lock.json"]);
   await (0,exec.exec)("git", ["commit", "--message", `${title}\n\n${commitBody}`]);
   await (0,exec.exec)("git", ["checkout", "-B", branch]);

--- a/dist/index.js
+++ b/dist/index.js
@@ -34061,8 +34061,7 @@ async function createOrUpdatePullRequest({
 
   await (0,exec.exec)("git", ["config", "user.name", author]);
   await (0,exec.exec)("git", ["config", "user.email", email]);
-  await (0,exec.exec)("git", ["add", "package.json"]);
-  await (0,exec.exec)("git", ["add", "package-lock.json"]);
+  await (0,exec.exec)("git", ["add", "package.json", "package-lock.json"]);
   await (0,exec.exec)("git", ["commit", "--message", `${title}\n\n${commitBody}`]);
   await (0,exec.exec)("git", ["checkout", "-B", branch]);
   await (0,exec.exec)("git", ["push", "--force", remote, `HEAD:${branch}`]);

--- a/lib/createOrUpdatePullRequest.js
+++ b/lib/createOrUpdatePullRequest.js
@@ -51,6 +51,7 @@ export default async function createOrUpdatePullRequest({
 
   await exec("git", ["config", "user.name", author]);
   await exec("git", ["config", "user.email", email]);
+  await exec("git", ["add", "package.json"]);
   await exec("git", ["add", "package-lock.json"]);
   await exec("git", ["commit", "--message", `${title}\n\n${commitBody}`]);
   await exec("git", ["checkout", "-B", branch]);

--- a/lib/createOrUpdatePullRequest.js
+++ b/lib/createOrUpdatePullRequest.js
@@ -51,8 +51,7 @@ export default async function createOrUpdatePullRequest({
 
   await exec("git", ["config", "user.name", author]);
   await exec("git", ["config", "user.email", email]);
-  await exec("git", ["add", "package.json"]);
-  await exec("git", ["add", "package-lock.json"]);
+  await exec("git", ["add", "package.json", "package-lock.json"]);
   await exec("git", ["commit", "--message", `${title}\n\n${commitBody}`]);
   await exec("git", ["checkout", "-B", branch]);
   await exec("git", ["push", "--force", remote, `HEAD:${branch}`]);


### PR DESCRIPTION
Hello,
As shown in the Action logs, there are cases where only the `package.json` file is updated, but currently, the program only stages `package-lock.json` for commit.
![image](https://github.com/user-attachments/assets/f6c5869c-504a-4f46-bc13-d94edb76cad0)
This leads to issues when we attempt to commit without having staged any files.
This PR addresses the problem by adding the `package.json` before committing.
Thanks!