### PR TITLE
feat: change `github_email` input default to include `github.actor_id`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,18 +30,18 @@ jobs:
 
 ### Inputs
 
-| Name             | Description                                   | Default                                        |
-| ---------------- | --------------------------------------------- | ---------------------------------------------- |
-| `github_token`   | GitHub token.                                 | `${{ github.token }}`                          |
-| `github_user`    | GitHub user name for commit changes.          | `${{ github.actor }}`                          |
-| `github_email`   | GitHub user email for commit changes.         | `${{ github.actor }}@users.noreply.github.com` |
-| `branch`         | Created branch.                               | `npm-audit-fix-action/fix`                     |
-| `default_branch` | Default branch.                               | Auto-detected.                                 |
-| `commit_title`   | Commit message and pull request title.        | `build(deps): npm audit fix`                   |
-| `labels`         | Labels for pull request (comma-separated).    | `dependencies, javascript, security`           |
-| `assignees`      | Assignees for pull request (comma-separated). | n/a                                            |
-| `npm_args`       | Arguments for the `npm` command.              | n/a                                            |
-| `path`           | Path to the project root directory.           | `.`                                            |
+| Name             | Description                                   | Default                                                               |
+| ---------------- | --------------------------------------------- | --------------------------------------------------------------------- |
+| `github_token`   | GitHub token.                                 | `${{ github.token }}`                                                 |
+| `github_user`    | GitHub user name for commit changes.          | `${{ github.actor }}`                                                 |
+| `github_email`   | GitHub user email for commit changes.         | `${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com` |
+| `branch`         | Created branch.                               | `npm-audit-fix-action/fix`                                            |
+| `default_branch` | Default branch.                               | Auto-detected.                                                        |
+| `commit_title`   | Commit message and pull request title.        | `build(deps): npm audit fix`                                          |
+| `labels`         | Labels for pull request (comma-separated).    | `dependencies, javascript, security`                                  |
+| `assignees`      | Assignees for pull request (comma-separated). | n/a                                                                   |
+| `npm_args`       | Arguments for the `npm` command.              | n/a                                                                   |
+| `path`           | Path to the project root directory.           | `.`                                                                   |
 
 See [`action.yml`](action.yml).
 

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
   github_email:
     description: "GitHub user email for commit changes."
     required: false
-    default: "${{ github.actor }}@users.noreply.github.com"
+    default: "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
   branch:
     description: "Created branch."
     required: false


### PR DESCRIPTION
Including `github.actor_id` is closer to actual commits.

Ref https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context
