### PR TITLE
ci(actions): move runner image from `ubuntu-latest` to `ubuntu-slim`

### DIFF
--- a/.github/workflows/npm-diff.yml
+++ b/.github/workflows/npm-diff.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   npm-diff:
     if: ${{ startsWith(github.head_ref, 'dependabot/npm_and_yarn/') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   unit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
     steps:
@@ -40,7 +40,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   smoke:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   smoke:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest # ubuntu-slim would require setup-node.
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/update-dist.yml
+++ b/.github/workflows/update-dist.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   update:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
This repo is pretty small. To save the CI cost.