### PR TITLE
test: show more rich coverage report via `npm run test:coverage`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: read
+    env:
+      FORCE_COLOR: 1
     steps:
       - name: Check out
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "pretest": "npm run lint",
     "test": "node --test",
     "test:watch": "npm --ignore-scripts test -- --watch",
-    "test:coverage": "npm --ignore-scripts test -- --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=test.lcov",
+    "test:coverage": "npm --ignore-scripts test -- --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=test.lcov --test-reporter=spec --test-reporter-destination=stdout",
     "lint": "ybiq run --npm lint:js lint:md lint:types lint:commit lint:styles",
     "lint:js": "eslint --cache",
     "lint:js:fix": "npm run lint:js -- --fix",


### PR DESCRIPTION
Example:

```
ℹ tests 12
ℹ suites 0
ℹ pass 12
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 1162.099959
ℹ start of coverage report
ℹ ------------------------------------------------------------------------------------
ℹ file                        | line % | branch % | funcs % | uncovered lines
ℹ ------------------------------------------------------------------------------------
ℹ lib                         |        |          |         |
ℹ  aggregateReport.js         |  96.67 |    90.91 |  100.00 | 14-15 19
ℹ  audit.js                   |  84.21 |    62.50 |  100.00 | 27-28 30-31 36-37
ℹ  buildCommitBody.js         | 100.00 |   100.00 |  100.00 |
ℹ  buildPullRequestBody.js    | 100.00 |   100.00 |  100.00 |
ℹ  constants.js               | 100.00 |   100.00 |  100.00 |
ℹ  listPackages.js            |  95.35 |    80.00 |  100.00 | 22-23
ℹ  npmArgs.js                 | 100.00 |    66.67 |  100.00 |
ℹ  packageRepoUrls.js         |  86.11 |    44.44 |  100.00 | 17-18 33-34 39-41 45-47
ℹ  utils                      |        |          |         |
ℹ   capitalize.js             |  90.00 |    66.67 |  100.00 | 9
ℹ   commaSeparatedList.js     | 100.00 |   100.00 |  100.00 |
ℹ   semverToNumber.js         | 100.00 |   100.00 |  100.00 |
ℹ   splitPackageName.js       |  90.91 |    80.00 |  100.00 | 10
ℹ ------------------------------------------------------------------------------------
ℹ all files                   |  95.14 |    84.54 |  100.00 |
ℹ ------------------------------------------------------------------------------------
ℹ end of coverage report
```