### PR TITLE
chore: remove unneeded `.prettierignore`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,0 @@
-/coverage
-/dist
-*.snap


### PR DESCRIPTION
By default, Prettier respects `.gitignore`. Ref:
https://prettier.io/docs/ignore#ignoring-files-prettierignore